### PR TITLE
Add suport for custom nodes and tv shows in playlist info

### DIFF
--- a/default.py
+++ b/default.py
@@ -111,21 +111,29 @@ class Main:
   #              Notify("found smart playlist. start: %i end: %i" % (startindex, endindex))
                 if (startindex > 0) and (endindex > 0):
                     playlistpath = self.id[startindex:endindex + 4]
-                    json_query = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Files.GetDirectory", "params": {"directory": "%s", "media": "video", "properties": ["playcount", "resume"]}, "id": 1}' % (playlistpath))
+                    json_query = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Files.GetDirectory", "params": {"directory": "%s", "media": "video", "properties": ["playcount", "resume", "episode", "watchedepisodes"]}, "id": 1}' % (playlistpath))
                     json_query = unicode(json_query, 'utf-8', errors='ignore')
                     json_response = simplejson.loads(json_query)
                     played = 0
                     inprogress = 0
+                    episodes = 0
+                    watchedepisodes = 0
                     numitems = json_response["result"]["limits"]["total"]
                     for item in json_response["result"]["files"]:
                         if item["playcount"] > 0:
                             played += 1
                         if item["resume"]["position"] > 0:
                             inprogress += 1
+                        if item.has_key('episode'):
+                            episodes += item["episode"]
+                        if item.has_key('watchedepisodes'):
+                            watchedepisodes += item["watchedepisodes"]
                     self.WINDOW.setProperty('PlaylistWatched', str(played))
-                    self.WINDOW.setProperty('PlaylistCount', str(numitems))        # Play an albums
+                    self.WINDOW.setProperty('PlaylistCount', str(numitems))
                     self.WINDOW.setProperty('PlaylistInProgress', str(inprogress))
                     self.WINDOW.setProperty('PlaylistUnWatched', str(numitems - played))
+                    self.WINDOW.setProperty('PlaylistEpisodes', str(episodes))
+                    self.WINDOW.setProperty('PlaylistEpisodesUnWatched', str(episodes - watchedepisodes))
             
         # Play an albums
         elif self.TYPE == "play_album":


### PR DESCRIPTION
Hi. I added in this pull request the support for custom video nodes (for example library://video/film/titles.xml) that works like playlists and I also added the parsing for tv show episodes.
If you want some change or implement it in a different way just ask it. If you want to rewrite it yourself no problem. It requires separate infolines for aeon nox skin (I will create a pull request for that too).
