### PR TITLE
Bugfixes for empty TV favourites and sort problem

### DIFF
--- a/default.py
+++ b/default.py
@@ -274,7 +274,7 @@ class Main:
                     if xbmc.abortRequested:
                         break
                     json_query2 = self.WINDOW.getProperty( prefix + "-data-" + str( item['tvshowid'] ) )
-                    if json_query:
+                    if json_query2:
                         json_query2 = simplejson.loads(json_query2)
                         if json_query2.has_key('result') and json_query2['result'] != None and json_query2['result'].has_key('episodes'):
                             for item2 in json_query2['result']['episodes']:

--- a/library.py
+++ b/library.py
@@ -161,8 +161,7 @@ class LibraryFunctions():
     def _fetch_recommended_episodes(self, useCache = False):
         def query_recommended_episodes():
             # First we get a list of all the in-progress TV shows.
-            json_query_string = self.json_query("VideoLibrary.GetTVShows", unplayed=True, properties=self.tvshow_properties, 
-                                         query_filter=self.inprogress_filter)
+            json_query_string = self.json_query("VideoLibrary.GetTVShows", unplayed=True, properties=self.tvshow_properties, sort={"order":"descending", "method":"lastplayed"}, query_filter=self.inprogress_filter)
             json_query = json.loads(json_query_string)
 
             # If we found any, find the oldest unwatched show for each one.
@@ -191,6 +190,8 @@ class LibraryFunctions():
             if favs['result']['favourites'] is None:
                 return None
             shows = json.loads(self.json_query("VideoLibrary.GetTVShows", unplayed=True, properties=self.tvshow_properties, limit=None))
+            if not shows.has_key('result') or not shows['result'].has_key('tvshows'):
+                return None
             fav_unwatched = [ show for show in shows['result']['tvshows'] if show['title'] in 
                               set([ fav['title'] for fav in favs['result']['favourites'] if fav['type'] == 'window']) ]
 


### PR DESCRIPTION
Hey,

These are fixes for recommended TV show sort ordering and for a problem if there are some favourites but none of them are TV shows.  I'm hoping this addresses all the problems on the message board.

I still have a bit of a question about the recent TV show ordering--that seems to use library://video/inprogressshows.xml rather than anything under plugin://service.library.data.provider directly.  It'd be an extreme coincidence for their sorting to get borked at the same time as my changes, so I'm guessing that that source uses us behind the scenes?  Do you have any insight on that?