### PR TITLE
Next Unwatched Episode per show

### DIFF
--- a/default.py
+++ b/default.py
@@ -87,6 +87,10 @@ class Main:
                 xbmcplugin.setContent(int(sys.argv[1]), 'episodes')
                 self.parse_tvshows( 'randomepisodes', 32007, full_liz )
                 xbmcplugin.addDirectoryItems(int(sys.argv[1]),full_liz)
+            elif type == "nextunwatchedepisodes":
+                xbmcplugin.setContent(int(sys.argv[1]), 'episodes')
+                self.parse_tvshows( 'nextunwatchedepisodes', 32021, full_liz )
+                xbmcplugin.addDirectoryItems(int(sys.argv[1]),full_liz)
             elif type == "recentvideos" :
                 listA = []
                 listB = []
@@ -536,6 +540,8 @@ class Main:
             return LIBRARY._fetch_recommended_episodes( self.USECACHE )
         elif request == "favouriteepisodes":
             return LIBRARY._fetch_favourite_episodes( self.USECACHE )
+        elif request == "nextunwatchedepisodes":
+            return LIBRARY._fetch_next_unwatched_episodes( self.USECACHE )
 
         elif request == "randomalbums":
             return LIBRARY._fetch_random_albums( self.USECACHE )

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -96,3 +96,6 @@ msgctxt "#32020"
 msgid "Favourite Episodes"
 msgstr ""
 
+msgctxt "#32021"
+msgid "Next Unwatched Episodes"
+msgstr ""

--- a/service.py
+++ b/service.py
@@ -87,6 +87,7 @@ class Main:
         LIBRARY._fetch_recent_movies()
         LIBRARY._fetch_recent_episodes()
         LIBRARY._fetch_recent_albums()
+        LIBRARY._fetch_next_unwatched_episodes()
             
     
     def _fetch_recommended( self ):
@@ -120,12 +121,14 @@ class Main:
             LIBRARY._fetch_recommended_episodes()
             LIBRARY._fetch_recent_episodes()
             LIBRARY._fetch_favourite_episodes()
+            LIBRARY._fetch_next_unwatched_episodes()
         elif type == 'video':
             #only on db update
             LIBRARY._fetch_recommended_movies()
             LIBRARY._fetch_recommended_episodes()
             LIBRARY._fetch_recent_movies()
             LIBRARY._fetch_recent_episodes()
+            LIBRARY._fetch_next_unwatched_episodes()
         elif type == 'music':
             LIBRARY._fetch_recommended_albums()
             LIBRARY._fetch_recent_albums()


### PR DESCRIPTION
It lists unwatched next episode per show on widget (just one episode per show).

Based on my [service add-on for quartz skin] (https://github.com/queeup/service.quartz.tvshelf). I think it's handy to have this on data provider service too.

I don't know if I use proper name's for function and type. I am open for all suggestions.

You don't have to pull this. Just shared my idea. Fell free to do what ever you want.

<a href="http://imgur.com/8niUP4R"><img src="http://i.imgur.com/8niUP4R.jpg?1" title="source: imgur.com" /></a>

