### PR TITLE
Use monitor.abortRequested instead of the old xbmc.sleep as specified…

### DIFF
--- a/service.py
+++ b/service.py
@@ -94,8 +94,10 @@ class Main:
     def _daemon(self):
         # deamon is meant to keep script running at all time
         count = 0
-        while not xbmc.abortRequested and self.WINDOW.getProperty('LibraryDataProvider_Running') == 'true':
-            xbmc.sleep(1000)
+        while not self.Monitor.abortRequested() and self.WINDOW.getProperty('LibraryDataProvider_Running') == 'true':
+            if self.Monitor.waitForAbort(1):
+                # Abort was requested while waiting. We should exit
+                break
             if not xbmc.Player().isPlayingVideo():
                 # Update random items
                 count += 1


### PR DESCRIPTION
… in http://kodi.wiki/view/Service_Add-ons

Please do some testing, as mine was quiet basic.