### PR TITLE
service: fix circular reference warning on shutdown.

### DIFF
--- a/service.py
+++ b/service.py
@@ -96,6 +96,8 @@ class Main:
         while not self.Monitor.abortRequested() and self.WINDOW.getProperty('LibraryDataProvider_Running') == 'true':
             if self.Monitor.waitForAbort(1):
                 # Abort was requested while waiting. We should exit
+                self.Monitor.update_listitems = None
+                self.Player.action = None
                 break
             if not xbmc.Player().isPlayingVideo():
                 # Update random items


### PR DESCRIPTION
Fixes the "has left several classes in memory" warning on shutdown, like this other add-on:
https://github.com/xbmc/repo-scripts/pull/35

(Sorry for not having a log at hand right now, but it's the very same warning mentioned there.)